### PR TITLE
Add and refactor tab bar implementation

### DIFF
--- a/BrainLabs.xcodeproj/project.pbxproj
+++ b/BrainLabs.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		8875D2872B87E3870014CA9C /* RecommendationsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8875D2862B87E3870014CA9C /* RecommendationsProvider.swift */; };
 		8875D2892B87E48F0014CA9C /* GameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8875D2882B87E48F0014CA9C /* GameModel.swift */; };
 		8875D2912B9F7E330014CA9C /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8875D2902B9F7E330014CA9C /* DIContainer.swift */; };
+		8875D2932B9FA1660014CA9C /* SafeAreaBottomPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8875D2922B9FA1660014CA9C /* SafeAreaBottomPadding.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -51,6 +52,7 @@
 		8875D2862B87E3870014CA9C /* RecommendationsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationsProvider.swift; sourceTree = "<group>"; };
 		8875D2882B87E48F0014CA9C /* GameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameModel.swift; sourceTree = "<group>"; };
 		8875D2902B9F7E330014CA9C /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
+		8875D2922B9FA1660014CA9C /* SafeAreaBottomPadding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaBottomPadding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +145,7 @@
 		8844D6A72B84107A0089FEB7 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				8875D2922B9FA1660014CA9C /* SafeAreaBottomPadding.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				8844D6AE2B8411C60089FEB7 /* HomeView.swift in Sources */,
 				8844D6982B7E86890089FEB7 /* CoreTabView.swift in Sources */,
 				8875D2842B87D03C0014CA9C /* HomeViewModel.swift in Sources */,
+				8875D2932B9FA1660014CA9C /* SafeAreaBottomPadding.swift in Sources */,
 				8875D2892B87E48F0014CA9C /* GameModel.swift in Sources */,
 				8844D6B22B84123A0089FEB7 /* ProfileView.swift in Sources */,
 				8844D6B02B8412240089FEB7 /* AllGamesView.swift in Sources */,

--- a/BrainLabs/Core/CoreTabView.swift
+++ b/BrainLabs/Core/CoreTabView.swift
@@ -32,44 +32,37 @@ struct CoreTabView: View {
     }
     
     var body: some View {
-        ZStack {
-            VStack {
-                TabView {
-                    HomeView(homeViewModel: DIContainer.shared.resolve(HomeViewModel.self))
-                        .tabItem {
-                            Label("Home", systemImage: "house")
-                        }
-                    
-                    AllGamesView()
-                        .tabItem {
-                            Label("Games", systemImage: "square.grid.3x3.fill")
-                        }
-                    
-                    ProfileView()
-                        .tabItem {
-                            Label("Profile", systemImage: "person")
-                        }
-                }
-            }
-            
-            VStack {
-                Spacer()
+        defaultTabView
+            .overlay(alignment: .bottom) {
                 CustomTabView(selectedTab: $selectedTab)
             }
+    }
+    
+    @ViewBuilder
+    var defaultTabView: some View {
+        TabView(selection: $selectedTab) {
+            HomeView(homeViewModel: DIContainer.shared.resolve(HomeViewModel.self))
+                .tag(Tab.home)
+            
+            AllGamesView()
+                .tag(Tab.games)
+            
+            ProfileView()
+                .tag(Tab.profile)
         }
     }
 }
 
-struct CustomTabView: View {
-    @Environment(\.verticalSizeClass) var verticalSizeClass
+/// Custom floating tab view with scale effect animations.
+///
+/// References:
+/// * https://www.youtube.com/watch?v=vzQDKYIKEb8
+/// * https://www.youtube.com/watch?v=Yg3cmpKNieU
+fileprivate struct CustomTabView: View {
     @Binding var selectedTab: Tab
     
     private var fillImage: String {
         selectedTab.symbolName + ".fill"
-    }
-    
-    private var bottomPadding: CGFloat {
-        verticalSizeClass == .compact ? 5 : 0
     }
     
     var body: some View {
@@ -77,7 +70,7 @@ struct CustomTabView: View {
             HStack {
                 ForEach(Tab.allCases, id: \.rawValue) { tab in
                     let isSelectedTab = selectedTab == tab
-                    let foregroundColor: Color = isSelectedTab ? .red : .gray
+                    let foregroundColor: Color = isSelectedTab ? .blue: .gray
                     
                     Spacer()
                     

--- a/BrainLabs/Core/CoreTabView.swift
+++ b/BrainLabs/Core/CoreTabView.swift
@@ -98,7 +98,7 @@ struct CustomTabView: View {
             .background(.thinMaterial)
             .clipShape(.rect(cornerRadius: 10))
             .padding(.horizontal)
-            .safeAreaPadding(.bottom, bottomPadding)
+            .safeAreaBottomPadding()
         }
     }
 }

--- a/BrainLabs/Core/CoreTabView.swift
+++ b/BrainLabs/Core/CoreTabView.swift
@@ -7,23 +7,98 @@
 
 import SwiftUI
 
+enum Tab: String, CaseIterable {
+    case home
+    case games
+    case profile
+    
+    var symbolName: String {
+        switch self {
+            case .home:
+                "house"
+            case .games:
+                "square.grid.3x3"
+            case .profile:
+                "person"
+        }
+    }
+}
+
 struct CoreTabView: View {
+    @State private var selectedTab: Tab = .home
+    
+    init() {
+        UITabBar.appearance().isHidden = true
+    }
+    
     var body: some View {
-        TabView {
-            HomeView(homeViewModel: DIContainer.shared.resolve(HomeViewModel.self))
-                .tabItem {
-                    Label("Home", systemImage: "house")
+        ZStack {
+            VStack {
+                TabView {
+                    HomeView(homeViewModel: DIContainer.shared.resolve(HomeViewModel.self))
+                        .tabItem {
+                            Label("Home", systemImage: "house")
+                        }
+                    
+                    AllGamesView()
+                        .tabItem {
+                            Label("Games", systemImage: "square.grid.3x3.fill")
+                        }
+                    
+                    ProfileView()
+                        .tabItem {
+                            Label("Profile", systemImage: "person")
+                        }
                 }
+            }
             
-            AllGamesView()
-                .tabItem {
-                    Label("Games", systemImage: "square.grid.3x3.fill")
+            VStack {
+                Spacer()
+                CustomTabView(selectedTab: $selectedTab)
+            }
+        }
+    }
+}
+
+struct CustomTabView: View {
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+    @Binding var selectedTab: Tab
+    
+    private var fillImage: String {
+        selectedTab.symbolName + ".fill"
+    }
+    
+    private var bottomPadding: CGFloat {
+        verticalSizeClass == .compact ? 5 : 0
+    }
+    
+    var body: some View {
+        VStack {
+            HStack {
+                ForEach(Tab.allCases, id: \.rawValue) { tab in
+                    let isSelectedTab = selectedTab == tab
+                    let foregroundColor: Color = isSelectedTab ? .red : .gray
+                    
+                    Spacer()
+                    
+                    Image(systemName: isSelectedTab ? fillImage : tab.symbolName)
+                        .font(.system(size: 22))
+                        .scaleEffect(isSelectedTab ? 1.25 : 1.0)
+                    .foregroundStyle(foregroundColor)
+                    .onTapGesture {
+                        withAnimation(.easeIn(duration: 0.1)) {
+                            selectedTab = tab
+                        }
+                    }
+                    .padding()
+                    
+                    Spacer()
                 }
-            
-            ProfileView()
-                .tabItem {
-                    Label("Profile", systemImage: "person")
-                }
+            }
+            .background(.thinMaterial)
+            .clipShape(.rect(cornerRadius: 10))
+            .padding(.horizontal)
+            .safeAreaPadding(.bottom, bottomPadding)
         }
     }
 }

--- a/BrainLabs/Core/DI/DIContainer.swift
+++ b/BrainLabs/Core/DI/DIContainer.swift
@@ -55,6 +55,6 @@ extension DIContainer {
                 recommendationsProvider: resolver.resolve(RecommendationsProvider.self)!
             )
         }
-        .inObjectScope(.transient)
+        .inObjectScope(.container)
     }
 }

--- a/BrainLabs/Core/DI/DIContainer.swift
+++ b/BrainLabs/Core/DI/DIContainer.swift
@@ -55,6 +55,6 @@ extension DIContainer {
                 recommendationsProvider: resolver.resolve(RecommendationsProvider.self)!
             )
         }
-        .inObjectScope(.container)
+        .inObjectScope(.transient)
     }
 }

--- a/BrainLabs/Presentation/Home/HomeView.swift
+++ b/BrainLabs/Presentation/Home/HomeView.swift
@@ -26,6 +26,7 @@ struct HomeView: View {
             .padding(20)
         } // scrollview
         .scrollIndicators(.hidden)
+        .contentMargins(.bottom, 60, for: .scrollContent)
     }
     
     @ViewBuilder

--- a/BrainLabs/Presentation/Home/HomeView.swift
+++ b/BrainLabs/Presentation/Home/HomeView.swift
@@ -26,6 +26,10 @@ struct HomeView: View {
             .padding(20)
         } // scrollview
         .scrollIndicators(.hidden)
+        /*
+         IMPORTANT: Content margins added here to account for potential
+         overlap with the custom tab view. 
+         */
         .contentMargins(.bottom, 60, for: .scrollContent)
     }
     

--- a/BrainLabs/Utilities/SafeAreaBottomPadding.swift
+++ b/BrainLabs/Utilities/SafeAreaBottomPadding.swift
@@ -1,0 +1,28 @@
+//
+//  SafeAreaBottomPadding.swift
+//  BrainLabs
+//
+//  Created by Kevin Vu on 3/11/24.
+//
+
+import SwiftUI
+
+struct SafeAreaBottomPadding: ViewModifier {
+    func body(content: Content) -> some View {
+        if UIApplication.shared.windows.first?.safeAreaInsets.bottom == 0 {
+            content.padding(.bottom)
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    /// Adds safe area bottom padding only when the device being used is a "small" type (i.e. one with
+    /// TouchID).
+    ///
+    /// Reference: https://www.hackingwithswift.com/forums/swiftui/adding-bottom-spacing-on-non-face-id-phones/12181
+    func safeAreaBottomPadding() -> some View {
+        modifier(SafeAreaBottomPadding())
+    }
+}


### PR DESCRIPTION
References used:
* https://www.youtube.com/watch?v=vzQDKYIKEb8
* https://www.youtube.com/watch?v=Yg3cmpKNieU

Add a custom floating tab bar with scale effect animations when selecting a tab. 
Important things of note:
* To link a custom tab view, we should pass a binding to the selected tab `@Binding var selectedTab` to some custom `Tab` enum. 
* From there, we need to tag each view to its corresponding tab case. See lines 45, 48, and 51 in `CoreTabView.swift`. This is what allows the base `TabView` to switch tabs based on the custom view's binding/selection.
* Since we are creating a custom tab view that floats as an overlay, we should add ending content margins for the home view so that it does not overlap with the tab view.